### PR TITLE
Merge attributesequences

### DIFF
--- a/example/en-ga/en.attribs_chunk.txt
+++ b/example/en-ga/en.attribs_chunk.txt
@@ -1,0 +1,4 @@
+gen = m f mf GD
+num = sg pl sp ND
+det_chunk = DEFART NODET DET
+neg_chunk = negative

--- a/example/en-ga/ga.attribs.txt
+++ b/example/en-ga/ga.attribs.txt
@@ -4,3 +4,4 @@ num = sg pl sp ND
 case = com gen voc dat
 mut = len hpref ecl defart
 pers = p1 p2 p3 PD
+strength = strong

--- a/example/en-ga/ga.attribs_chunk.txt
+++ b/example/en-ga/ga.attribs_chunk.txt
@@ -1,0 +1,5 @@
+mut = len hpref ecl defart LENGAN LENPREP
+gen = m f mf GD
+num = sg pl sp ND
+case = case = com gen voc dat GEN2
+det_chunk = DEFART NODET DET RMART

--- a/example/en-ga/ga.attribs_chunk.txt
+++ b/example/en-ga/ga.attribs_chunk.txt
@@ -1,5 +1,5 @@
 mut = len hpref ecl defart LENGAN LENPREP
 gen = m f mf GD
 num = sg pl sp ND
-case = case = com gen voc dat GEN2
+case = com gen voc dat GEN2
 det_chunk = DEFART NODET DET RMART

--- a/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
+++ b/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
@@ -76,4 +76,13 @@ public class MergedAttributeSequences {
             sequences.put(as.name, tags);
         }
     }
+    public Map<String, Set<String>> getSequences() {
+        return sequences;
+    }
+    public Map<String, Boolean> getClippable() {
+        return clippable;
+    }
+    public boolean isClippable(String s) {
+        return clippable.get(s);
+    }
 }

--- a/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
+++ b/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
@@ -35,10 +35,14 @@ public class MergedAttributeSequences {
     List<AttributeSequence> source_chunk;
     List<AttributeSequence> target_chunk;
     Map<String, Set<String>> sequences;
+    Map<String, Set<String>> chunk_sequences;
     Map<String, Boolean> clippable;
+    Map<String, Boolean> agreement;
     MergedAttributeSequences() {
         this.sequences = new HashMap<String, Set<String>>();
+        this.chunk_sequences = new HashMap<String, Set<String>>();
         this.clippable = new HashMap<String, Boolean>();
+        this.agreement = new HashMap<String, Boolean>();
     }
     public MergedAttributeSequences(List<AttributeSequence> source, List<AttributeSequence> target, List<AttributeSequence> source_chunk, List<AttributeSequence> target_chunk) {
         this();
@@ -56,7 +60,14 @@ public class MergedAttributeSequences {
             clippable.put(as.name, true);
         }
         for(AttributeSequence as : target) {
-            mergeInnerAdd(as);
+            if(sequences.containsKey(as.name)) {
+                sequences.get(as.name).addAll(as.tags);
+            } else {
+                clippable.put(as.name, false);
+                Set<String> tags = new HashSet<String>();
+                tags.addAll(as.tags);
+                sequences.put(as.name, tags);
+            }
         }
         for(AttributeSequence as : source_chunk) {
             mergeInnerAdd(as);
@@ -68,21 +79,32 @@ public class MergedAttributeSequences {
 
     private void mergeInnerAdd(AttributeSequence as) {
         if(sequences.containsKey(as.name)) {
+            agreement.put(as.name, true);
             sequences.get(as.name).addAll(as.tags);
         } else {
             clippable.put(as.name, false);
             Set<String> tags = new HashSet<String>();
             tags.addAll(as.tags);
-            sequences.put(as.name, tags);
+            chunk_sequences.put(as.name, tags);
         }
     }
     public Map<String, Set<String>> getSequences() {
         return sequences;
+    }
+    public Map<String, Set<String>> getChunkSequences() {
+        return chunk_sequences;
     }
     public Map<String, Boolean> getClippable() {
         return clippable;
     }
     public boolean isClippable(String s) {
         return clippable.get(s);
+    }
+    public boolean hasChunkAgreement(String s) {
+        if(agreement.containsKey(s)) {
+            return agreement.get(s);
+        } else {
+            return false;
+        }
     }
 }

--- a/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
+++ b/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
@@ -47,14 +47,24 @@ public class MergedAttributeSequences {
             clippable.put(as.name, true);
         }
         for(AttributeSequence as : target) {
-            if(sequences.containsKey(as.name)) {
-                sequences.get(as.name).addAll(as.tags);
-            } else {
-                clippable.put(as.name, false);
-                Set<String> tags = new HashSet<String>();
-                tags.addAll(as.tags);
-                sequences.put(as.name, tags);
-            }
+            mergeInnerAdd(as);
+        }
+        for(AttributeSequence as : source_chunk) {
+            mergeInnerAdd(as);
+        }
+        for(AttributeSequence as : target_chunk) {
+            mergeInnerAdd(as);
+        }
+    }
+
+    private void mergeInnerAdd(AttributeSequence as) {
+        if(sequences.containsKey(as.name)) {
+            sequences.get(as.name).addAll(as.tags);
+        } else {
+            clippable.put(as.name, false);
+            Set<String> tags = new HashSet<String>();
+            tags.addAll(as.tags);
+            sequences.put(as.name, tags);
         }
     }
 }

--- a/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
+++ b/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright © 2017 Trinity College, Dublin
+ * Irish Speech and Language Technology Research Centre
+ * Cóipcheart © 2017 Coláiste na Tríonóide, Baile Átha Cliath
+ * An tIonad taighde do Theicneolaíocht Urlabhra agus Teangeolaíochta na Gaeilge
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package ie.tcd.slscs.itut.ApertiumTransfer.Text;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MergedAttributeSequences {
+    List<AttributeSequence> source;
+    List<AttributeSequence> target;
+    List<AttributeSequence> source_chunk;
+    List<AttributeSequence> target_chunk;
+    Map<String, List<String>> sequences;
+    MergedAttributeSequences() {
+        this.sequences = new HashMap<String, List<String>>();
+    }
+    void merge() {
+        for(AttributeSequence as : source) {
+            String key = as.name;
+            List<String> tags = as.tags;
+            sequences.put(as.name, as.tags);
+        }
+    }
+}

--- a/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
+++ b/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
@@ -42,8 +42,6 @@ public class MergedAttributeSequences {
     }
     void merge() {
         for(AttributeSequence as : source) {
-            String key = as.name;
-            List<String> tags = as.tags;
             sequences.put(as.name, as.tags);
         }
     }

--- a/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
+++ b/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
@@ -38,6 +38,15 @@ public class MergedAttributeSequences {
     Map<String, Boolean> clippable;
     MergedAttributeSequences() {
         this.sequences = new HashMap<String, Set<String>>();
+        this.clippable = new HashMap<String, Boolean>();
+    }
+    public MergedAttributeSequences(List<AttributeSequence> source, List<AttributeSequence> target, List<AttributeSequence> source_chunk, List<AttributeSequence> target_chunk) {
+        this();
+        this.source = source;
+        this.source_chunk = source_chunk;
+        this.target = target;
+        this.target_chunk = target_chunk;
+        merge();
     }
     void merge() {
         for(AttributeSequence as : source) {

--- a/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
+++ b/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
@@ -27,22 +27,22 @@
 
 package ie.tcd.slscs.itut.ApertiumTransfer.Text;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class MergedAttributeSequences {
     List<AttributeSequence> source;
     List<AttributeSequence> target;
     List<AttributeSequence> source_chunk;
     List<AttributeSequence> target_chunk;
-    Map<String, List<String>> sequences;
+    Map<String, Set<String>> sequences;
     MergedAttributeSequences() {
-        this.sequences = new HashMap<String, List<String>>();
+        this.sequences = new HashMap<String, Set<String>>();
     }
     void merge() {
         for(AttributeSequence as : source) {
-            sequences.put(as.name, as.tags);
+            Set<String> tags = new HashSet<String>();
+            tags.addAll(as.tags);
+            sequences.put(as.name, tags);
         }
     }
 }

--- a/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
+++ b/src/main/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequences.java
@@ -35,6 +35,7 @@ public class MergedAttributeSequences {
     List<AttributeSequence> source_chunk;
     List<AttributeSequence> target_chunk;
     Map<String, Set<String>> sequences;
+    Map<String, Boolean> clippable;
     MergedAttributeSequences() {
         this.sequences = new HashMap<String, Set<String>>();
     }
@@ -43,6 +44,17 @@ public class MergedAttributeSequences {
             Set<String> tags = new HashSet<String>();
             tags.addAll(as.tags);
             sequences.put(as.name, tags);
+            clippable.put(as.name, true);
+        }
+        for(AttributeSequence as : target) {
+            if(sequences.containsKey(as.name)) {
+                sequences.get(as.name).addAll(as.tags);
+            } else {
+                clippable.put(as.name, false);
+                Set<String> tags = new HashSet<String>();
+                tags.addAll(as.tags);
+                sequences.put(as.name, tags);
+            }
         }
     }
 }

--- a/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
@@ -1,0 +1,5 @@
+import static org.junit.Assert.*;
+
+public class MergedAttributeSequencesTest {
+
+}

--- a/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
@@ -72,7 +72,7 @@ public class MergedAttributeSequencesTest extends TestCase {
         assertEquals(true, mas.hasChunkAgreement("num"));
         assertEquals(false, mas.hasChunkAgreement("neg_chunk"));
     }
-    public void getChunkSequences() throws Exception {
+    public void testGetChunkSequences() throws Exception {
         List<AttributeSequence> asinsrc = AttributeSequence.fromFile(new ByteArrayInputStream(insrc.getBytes()));
         List<AttributeSequence> asintrg = AttributeSequence.fromFile(new ByteArrayInputStream(intrg.getBytes()));
         List<AttributeSequence> asinsrcch = AttributeSequence.fromFile(new ByteArrayInputStream(insrcch.getBytes()));

--- a/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
@@ -57,7 +57,7 @@ public class MergedAttributeSequencesTest extends TestCase {
     String intrgch = "mut = len hpref ecl defart LENGAN LENPREP\n" +
             "gen = m f mf GD\n" +
             "num = sg pl sp ND\n" +
-            "case = case = com gen voc dat GEN2\n" +
+            "case = com gen voc dat GEN2\n" +
             "det_chunk = DEFART NODET DET RMART";
     public void testMerge() throws Exception {
         List<AttributeSequence> asinsrc = AttributeSequence.fromFile(new ByteArrayInputStream(insrc.getBytes()));

--- a/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
@@ -79,8 +79,10 @@ public class MergedAttributeSequencesTest extends TestCase {
         List<AttributeSequence> asintrgch = AttributeSequence.fromFile(new ByteArrayInputStream(intrgch.getBytes()));
         MergedAttributeSequences mas = new MergedAttributeSequences(asinsrc, asintrg, asinsrcch, asintrgch);
         Map<String, Set<String>> foo = mas.getChunkSequences();
-        assertEquals(5, foo.size());
-        assertEquals("", foo.keySet().toString());
+        assertEquals(2, foo.size());
+        assertEquals(true, foo.containsKey("det_chunk"));
+        assertEquals(true, foo.containsKey("neg_chunk"));
+        assertEquals(false, foo.containsKey("gen"));
     }
 
 }

--- a/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
@@ -1,5 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright © 2017 Trinity College, Dublin
+ * Irish Speech and Language Technology Research Centre
+ * Cóipcheart © 2017 Coláiste na Tríonóide, Baile Átha Cliath
+ * An tIonad taighde do Theicneolaíocht Urlabhra agus Teangeolaíochta na Gaeilge
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package ie.tcd.slscs.itut.ApertiumTransfer.Text;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
 import static org.junit.Assert.*;
 
-public class MergedAttributeSequencesTest {
+public class MergedAttributeSequencesTest extends TestCase {
+    String insrc = "grade = comp sup\n" +
+            "gen = m f nt mf GD\n" +
+            "num = sg pl sp ND\n" +
+            "pers = p1 p2 p3 PD\n" +
+            "rel_type = nn an adv\n" +
+            "a_noun = n a.acr np.top np.ant np.cog np.al\n" +
+            "a_adj = adj adj.sint\n" +
+            "tense = pri pres past inf pp ger pprs subs";
+    String intrg = "grade = comp\n" +
+            "gen = m f mf GD\n" +
+            "num = sg pl sp ND\n" +
+            "case = com gen voc dat\n" +
+            "mut = len hpref ecl defart\n" +
+            "pers = p1 p2 p3 PD";
+    String insrcch = "gen = m f mf GD\n" +
+            "num = sg pl sp ND\n" +
+            "det_chunk = DEFART NODET DET\n" +
+            "neg_chunk = negative";
+    String intrgch = "mut = len hpref ecl defart LENGAN LENPREP\n" +
+            "gen = m f mf GD\n" +
+            "num = sg pl sp ND\n" +
+            "case = case = com gen voc dat GEN2\n" +
+            "det_chunk = DEFART NODET DET RMART";
+    public void testMerge() throws Exception {
+
+    }
+    public void getChunkSequences() throws Exception {
+    }
 
 }

--- a/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
@@ -80,6 +80,7 @@ public class MergedAttributeSequencesTest extends TestCase {
         MergedAttributeSequences mas = new MergedAttributeSequences(asinsrc, asintrg, asinsrcch, asintrgch);
         Map<String, Set<String>> foo = mas.getChunkSequences();
         assertEquals(5, foo.size());
+        assertEquals("", foo.keySet().toString());
     }
 
 }

--- a/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
@@ -65,6 +65,9 @@ public class MergedAttributeSequencesTest extends TestCase {
         List<AttributeSequence> asinsrcch = AttributeSequence.fromFile(new ByteArrayInputStream(insrcch.getBytes()));
         List<AttributeSequence> asintrgch = AttributeSequence.fromFile(new ByteArrayInputStream(intrgch.getBytes()));
         MergedAttributeSequences mas = new MergedAttributeSequences(asinsrc, asintrg, asinsrcch, asintrgch);
+        assertEquals(false, mas.isClippable("case"));
+        assertEquals(true, mas.isClippable("gen"));
+        assertEquals(true, mas.hasChunkAgreement("num"));
     }
     public void getChunkSequences() throws Exception {
     }

--- a/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
@@ -30,6 +30,9 @@ package ie.tcd.slscs.itut.ApertiumTransfer.Text;
 import junit.framework.TestCase;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.util.List;
+
 import static org.junit.Assert.*;
 
 public class MergedAttributeSequencesTest extends TestCase {
@@ -57,7 +60,11 @@ public class MergedAttributeSequencesTest extends TestCase {
             "case = case = com gen voc dat GEN2\n" +
             "det_chunk = DEFART NODET DET RMART";
     public void testMerge() throws Exception {
-
+        List<AttributeSequence> asinsrc = AttributeSequence.fromFile(new ByteArrayInputStream(insrc.getBytes()));
+        List<AttributeSequence> asintrg = AttributeSequence.fromFile(new ByteArrayInputStream(intrg.getBytes()));
+        List<AttributeSequence> asinsrcch = AttributeSequence.fromFile(new ByteArrayInputStream(insrcch.getBytes()));
+        List<AttributeSequence> asintrgch = AttributeSequence.fromFile(new ByteArrayInputStream(intrgch.getBytes()));
+        MergedAttributeSequences mas = new MergedAttributeSequences(asinsrc, asintrg, asinsrcch, asintrgch);
     }
     public void getChunkSequences() throws Exception {
     }

--- a/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
+++ b/src/test/java/ie/tcd/slscs/itut/ApertiumTransfer/Text/MergedAttributeSequencesTest.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -68,8 +70,16 @@ public class MergedAttributeSequencesTest extends TestCase {
         assertEquals(false, mas.isClippable("case"));
         assertEquals(true, mas.isClippable("gen"));
         assertEquals(true, mas.hasChunkAgreement("num"));
+        assertEquals(false, mas.hasChunkAgreement("neg_chunk"));
     }
     public void getChunkSequences() throws Exception {
+        List<AttributeSequence> asinsrc = AttributeSequence.fromFile(new ByteArrayInputStream(insrc.getBytes()));
+        List<AttributeSequence> asintrg = AttributeSequence.fromFile(new ByteArrayInputStream(intrg.getBytes()));
+        List<AttributeSequence> asinsrcch = AttributeSequence.fromFile(new ByteArrayInputStream(insrcch.getBytes()));
+        List<AttributeSequence> asintrgch = AttributeSequence.fromFile(new ByteArrayInputStream(intrgch.getBytes()));
+        MergedAttributeSequences mas = new MergedAttributeSequences(asinsrc, asintrg, asinsrcch, asintrgch);
+        Map<String, Set<String>> foo = mas.getChunkSequences();
+        assertEquals(5, foo.size());
     }
 
 }


### PR DESCRIPTION
The idea here is to take two sets of attribute sequences per language: one for tokens, one for chunks, and merge them. If there's no entry in the source tokens set, there is no corresponding clip, so a variable has to be generated